### PR TITLE
Bump upper bounds on the hspec package

### DIFF
--- a/map-syntax.cabal
+++ b/map-syntax.cabal
@@ -63,5 +63,5 @@ Test-suite testsuite
     HUnit                      >= 1.2      && < 2,
     mtl                        >= 2.0      && < 2.3,
     QuickCheck                 >= 2.3.0.2  && < 3,
-    hspec                      >= 2.2.3    && < 2.4,
+    hspec                      >= 2.2.3    && < 2.5,
     transformers               >= 0.3      && < 0.6


### PR DESCRIPTION
Needed to build under `nixpkgs-unstable` and LTS-8.5.