### PR TITLE
Bump base to build under GHC 9.0.1.

### DIFF
--- a/map-syntax.cabal
+++ b/map-syntax.cabal
@@ -38,7 +38,7 @@ Library
     Data.Map.Syntax
 
   build-depends:
-    base                       >= 4.3 && < 4.15,
+    base                       >= 4.3 && < 4.16,
     containers                 >= 0.3 && < 0.7,
     mtl                        >= 2.0 && < 2.3
 

--- a/map-syntax.cabal
+++ b/map-syntax.cabal
@@ -22,7 +22,11 @@ Tested-With:
   GHC == 8.0.2,
   GHC == 8.2.2,
   GHC == 8.4.4,
-  GHC == 8.6.3
+  GHC == 8.6.3,
+  GHC == 8.8.4,
+  GHC == 8.10.7,
+  GHC == 9.0.2,
+  GHC == 9.2.1
 
 extra-source-files:
   .ghci,
@@ -38,7 +42,7 @@ Library
     Data.Map.Syntax
 
   build-depends:
-    base                       >= 4.3 && < 4.16,
+    base                       >= 4.3 && < 4.17,
     containers                 >= 0.3 && < 0.7,
     mtl                        >= 2.0 && < 2.3
 
@@ -78,5 +82,5 @@ Test-suite testsuite
     HUnit                      >= 1.2      && < 2,
     mtl,
     QuickCheck                 >= 2.3.0.2  && < 3,
-    hspec                      >= 2.2.3    && < 2.8,
-    transformers               >= 0.3      && < 0.6
+    hspec                      >= 2.2.3    && < 2.10,
+    transformers               >= 0.3      && < 0.7


### PR DESCRIPTION
However, with `QualifiedDo` now landed, there may be new ways of accomplishing what this package does.